### PR TITLE
fix: add validation to `preferIn` option

### DIFF
--- a/src/no-mix-dearu-desumasu.js
+++ b/src/no-mix-dearu-desumasu.js
@@ -4,6 +4,7 @@ import { RuleHelper, IgnoreNodeManager } from "textlint-rule-helper";
 import BodyMixedChecker from "./BodyMixedChecker";
 import HeaderMixedChecker from "./HeaderMixedChecker";
 import ListMixedChecker from "./ListMixedChecker";
+
 export const PreferTypes = {
     DESUMASU: "ですます",
     DEARU: "である"
@@ -18,11 +19,28 @@ const defaultOptions = {
     strict: false
 };
 
+const allowedTypes = [/*auto*/ "", PreferTypes.DESUMASU, PreferTypes.DEARU];
+const assertPreferOption = (preferType) => {
+    if (!preferType) {
+        return;
+    }
+    if (!allowedTypes.includes(preferType)) {
+        throw new Error(`preferInHeader, preferInBody, preferInList は ${allowedTypes.map((type) => {
+            return `"${type}"`;
+        })} のどれかである必要があります。. 
+
+実際の値: "${preferType}"`);
+    }
+};
+
 module.exports = function noMixedDearuDesumasu(context, options = defaultOptions) {
     const { Syntax, getSource } = context;
     const helper = new RuleHelper(context);
     const ignoreManager = new IgnoreNodeManager();
     const isStrict = options.strict !== undefined ? options.strict : defaultOptions.strict;
+    assertPreferOption(options.preferInHeader);
+    assertPreferOption(options.preferInBody);
+    assertPreferOption(options.preferInList);
     const bodyChecker = new BodyMixedChecker(context, {
         preferDesumasu: options.preferInBody === PreferTypes.DESUMASU,
         preferDearu: options.preferInBody === PreferTypes.DEARU,

--- a/src/no-mix-dearu-desumasu.js
+++ b/src/no-mix-dearu-desumasu.js
@@ -27,7 +27,7 @@ const assertPreferOption = (preferType) => {
     if (!allowedTypes.includes(preferType)) {
         throw new Error(`preferInHeader, preferInBody, preferInList は ${allowedTypes.map((type) => {
             return `"${type}"`;
-        })} のどれかである必要があります。. 
+        })} のどれかである必要があります。 
 
 実際の値: "${preferType}"`);
     }

--- a/test/no-mix-dearu-desumasu-test.js
+++ b/test/no-mix-dearu-desumasu-test.js
@@ -465,7 +465,7 @@ CはDです。
 一方、AとCは同じものである。
 `,
             options: {
-                preferInBody: "です",
+                preferInBody: "ですます",
                 strict: false
             },
             errors: [
@@ -488,7 +488,7 @@ CはDになります。
 一方、AとCは同じものである。
 `,
             options: {
-                preferInBody: "です",
+                preferInBody: "ですます",
                 strict: false
             },
             errors: [


### PR DESCRIPTION
間違ったオプションの値を指定した場合にエラーにならずに、自動の判定になっていた。